### PR TITLE
Installer for Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,3 +303,4 @@ __pycache__/
 
 # OpenCover UI analysis results
 OpenCover/
+/Build/CI/tools

--- a/Build/CI/build.cake
+++ b/Build/CI/build.cake
@@ -1,0 +1,165 @@
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.4.0
+#addin "Cake.FileHelpers"
+#addin "Cake.IIS"
+#tool nuget:?package=GitVersion.CommandLine
+#tool nuget:?package=Tools.InnoSetup
+//////////////////////////////////////////////////////////////////////
+// ARGUMENTS
+//////////////////////////////////////////////////////////////////////
+const string commandStr = "command";
+const string buildStr = "build";
+const string cleanStr ="clean";
+const string packStr ="pack";
+const string customCommandStr = "Command";
+
+
+const string solutionPath = "../../QuickDeploy.sln";
+const string sourcePath ="../../";
+const string setupScriptPath = "../Scripts/Windows/setup.iss";
+
+class CommandProcess
+{
+    public CommandProcess(string commandName, string shortcut1, string shortcut2,string shortcut3, string description)
+    {
+        this.CommandName = commandName.Trim();
+        this.Shortcut1 = shortcut1.Trim();
+        this.Shortcut2 = shortcut2.Trim();
+        this.Shortcut3 = shortcut3.Trim();        
+        this.Description = description.Trim();
+    }
+
+    public string CommandName {get; private set;}
+    public string Shortcut1 {get; private set;}
+    public string Shortcut2 {get; private set;}
+    public string Shortcut3 {get; private set;}
+    public string Description {get; private set;}
+
+    public string Shortcuts
+    {
+        get 
+        {
+            return Shortcut1 + (Shortcut2 == "" ? "" : "," + Shortcut2) +(Shortcut3 == "" ?  "" : "," + Shortcut3);
+        }
+    }
+}
+
+List<CommandProcess> commandList = new List<CommandProcess>()
+{
+    new CommandProcess(buildStr,"b", "01" , "1","build the monitoR project"),
+    new CommandProcess(cleanStr,"c", "" , "","clean obj/bin folders"),
+    new CommandProcess(packStr,"pkg", "" , "","Package the application")
+};
+
+var target = Argument("target", "Default");
+var configuration = Argument("configuration", "Release");
+var command = Argument(commandStr, "");
+
+//////////////////////////////////////////////////////////////////////
+// TASKS
+//////////////////////////////////////////////////////////////////////
+
+Task("Default")
+    .IsDependentOn(customCommandStr);
+
+Task(buildStr)
+    .Does(() =>
+{
+    Warning("Restoring Nuget Packages:");
+    NuGetRestore(solutionPath);
+
+    Warning("Building MonitoR Source:");
+    DotNetBuild(solutionPath, settings =>
+    settings.SetConfiguration("Release")
+        .SetVerbosity(Verbosity.Minimal)
+        .WithTarget("Build")
+        .WithProperty("TreatWarningsAsErrors","true"));   
+});
+
+
+Task(cleanStr)
+    .Does(() =>
+{
+    var path = MakeAbsolute(Directory(sourcePath)).FullPath;
+    Warning("Cleaning bin/obj folders from Path " + path);
+    CleanDirectories(path + "/**/bin/" + "Debug");
+    CleanDirectories(path + "/**/bin/" + "Release");
+    CleanDirectories(path + "/**/obj/" + "Debug");   
+    CleanDirectories(path + "/**/obj/" + "Release");
+});
+
+Task(packStr)
+    .IsDependentOn(buildStr)
+    .Does(() =>
+{
+    FilePath innoPath = Context.Tools.Resolve("iscc.exe");
+    Warning("Using Innosetup path from - " + innoPath);
+    InnoSetup(setupScriptPath, new InnoSetupSettings(){
+        ToolPath = innoPath,
+    });
+});
+
+//////////////////////////////////////////////////////////////////////
+// TASK TARGETS
+//////////////////////////////////////////////////////////////////////
+
+
+Task(customCommandStr)
+    .Does(() =>
+{
+    var command = Argument<string>(commandStr);
+    
+    if(command == null || command.Trim() == "")
+    {
+        if (command.Trim().Length > 0)
+            Error("Invalid command");
+        else
+            Error("No Parameter specified");
+        ShowUsage();        
+        return;
+    }
+
+    command = command.Trim().ToLower();
+
+    var item = commandList.FirstOrDefault(x=> x.CommandName.Trim().ToLower() == command || x.Shortcut1.Trim().ToLower() == command || x.Shortcut2.Trim().ToLower() == command|| x.Shortcut3.Trim().ToLower() == command);
+    if (item == null)
+    {
+        Error("Invalid command - " + command);
+        ShowUsage();
+        return;
+    }
+
+    RunTarget(item.CommandName);
+
+})
+.OnError(exception =>
+{
+    Error("Error when executing command - " + exception.Message + " - ST - "+ exception.StackTrace);
+});
+
+void ShowUsage()
+{
+    Warning("=====");
+    Warning("Usage");
+    Warning("=====");
+    Warning("ci.bat <Command>");
+    int commandPadding = 20;
+    int shortcutPadding = 10;
+
+    var header = "Command".PadRight(commandPadding,' ')+" - "+"Shortcut".PadRight(shortcutPadding,' ')+" - "+"Description";
+    var line = "=".PadRight(header.Length + 30,'=');
+
+    Warning(line);
+    Warning(header);
+    Warning(line);
+    foreach(var item in commandList)
+    {
+        Warning(item.CommandName.PadRight(commandPadding,' ')+" - "+item.Shortcuts.PadRight(shortcutPadding,' ')+" - "+item.Description);
+    }
+    Warning(line);
+}
+
+//////////////////////////////////////////////////////////////////////
+// EXECUTION
+//////////////////////////////////////////////////////////////////////
+
+RunTarget(target);

--- a/Build/CI/build.ps1
+++ b/Build/CI/build.ps1
@@ -1,0 +1,189 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER Experimental
+Tells Cake to use the latest Roslyn release.
+.PARAMETER WhatIf
+Performs a dry run of the build script.
+No tasks will be executed.
+.PARAMETER Mono
+Tells Cake to use the Mono scripting engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+https://cakebuild.net
+
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target = "Default",
+    [ValidateSet("Release", "Debug")]
+    [string]$Configuration = "Release",
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity = "Verbose",
+    [switch]$Experimental,
+    [Alias("DryRun","Noop")]
+    [switch]$WhatIf,
+    [switch]$Mono,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
+Write-Host "Preparing to run script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
+
+# Should we use mono?
+$UseMono = "";
+if($Mono.IsPresent) {
+    Write-Verbose -Message "Using the Mono based scripting engine."
+    $UseMono = "-mono"
+}
+
+# Should we use the new Roslyn?
+$UseExperimental = "";
+if($Experimental.IsPresent -and !($Mono.IsPresent)) {
+    Write-Verbose -Message "Using experimental version of Roslyn."
+    $UseExperimental = "-experimental"
+}
+
+# Is this a dry run?
+$UseDryRun = "";
+if($WhatIf.IsPresent) {
+    $UseDryRun = "-dryrun"
+}
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Make sure that packages.config exist.
+if (!(Test-Path $PACKAGES_CONFIG)) {
+    Write-Verbose -Message "Downloading packages.config..."
+    try { (New-Object System.Net.WebClient).DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
+        Throw "Could not download packages.config."
+    }
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        (New-Object System.Net.WebClient).DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
+
+# Restore tools from NuGet?
+if(-Not $SkipToolPackageRestore.IsPresent) {
+    Push-Location
+    Set-Location $TOOLS_DIR
+
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+    }
+
+    Write-Verbose -Message "Restoring tools from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occured while restoring NuGet tools."
+    }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+    Pop-Location
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+# Start Cake
+Write-Host "Running script..."
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" --settings_skipverification=true -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+exit $LASTEXITCODE

--- a/Build/Scripts/Windows/setup.iss
+++ b/Build/Scripts/Windows/setup.iss
@@ -1,0 +1,153 @@
+#define MyAppName "QuickDeploy Server"
+#define MyAppVersion "0.1"
+#define MyAppPublisher "QuickDeploy"
+#define MyAppURL "https://github.com/Toqe/QuickDeploy"
+#define ServiceFileName "QuickDeploy.ServerService.exe"
+
+[Setup]
+AppId={{70718A33-9119-40CA-9857-A4AE950FCDA4}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+;AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={pf}\QuickDeploy
+DefaultGroupName={#MyAppName}
+OutputDir=..\..\..\bin\setup
+OutputBaseFilename=quickDeploy-server-setup
+Compression=lzma
+SolidCompression=yes
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; OnlyBelowVersion: 0,6.1
+
+[Files]
+Source: "..\..\..\bin\*.*"; DestDir: "{app}\Server"; Flags: ignoreversion;Excludes:*.pdb,*.xml
+
+[Icons]
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+
+[Code]
+
+const
+  NET_FW_SCOPE_ALL = 0;
+  NET_FW_IP_VERSION_ANY = 2;
+
+procedure SetFirewallException(AppName,FileName:string);
+var
+  FirewallObject: Variant;
+  FirewallManager: Variant;
+  FirewallProfile: Variant;
+begin
+  try
+    FirewallObject := CreateOleObject('HNetCfg.FwAuthorizedApplication');
+    FirewallObject.ProcessImageFileName := FileName;
+    FirewallObject.Name := AppName;
+    FirewallObject.Scope := NET_FW_SCOPE_ALL;
+    FirewallObject.IpVersion := NET_FW_IP_VERSION_ANY;
+    FirewallObject.Enabled := True;
+    FirewallManager := CreateOleObject('HNetCfg.FwMgr');
+    FirewallProfile := FirewallManager.LocalPolicy.CurrentProfile;
+    FirewallProfile.AuthorizedApplications.Add(FirewallObject);
+  except
+  end;
+end;
+
+procedure RemoveFirewallException( FileName:string );
+var
+  FirewallManager: Variant;
+  FirewallProfile: Variant;
+begin
+  try
+    FirewallManager := CreateOleObject('HNetCfg.FwMgr');
+    FirewallProfile := FirewallManager.LocalPolicy.CurrentProfile;
+    FireWallProfile.AuthorizedApplications.Remove(FileName);
+  except
+  end;
+end;
+
+function KillProcess(FileName:string):Boolean;
+var
+  ResultCode:Integer;
+begin
+  if Exec(ExpandConstant('{sys}\taskkill.exe'), '/im '+ FileName + ' /f /t ', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) = false then  
+  begin
+    if Exec(ExpandConstant('{sys}\tskill.exe'), FileName + ' /A', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) = false then  
+      result := false
+    else
+      result := true;
+  end;
+end;
+
+function DoServiceOperation(op:string;canKillProcess:Boolean):Boolean;
+var
+  ResultCode:Integer;
+begin
+  if (canKillProcess) then
+  begin
+    KillProcess('mmc');
+    KillProcess('{#ServiceFileName}');
+  end;
+
+  if Exec(ExpandConstant('{app}\Server\{#ServiceFileName}'), op, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then  
+  begin
+    Result := ResultCode = 0;
+    Exit;
+  end;
+  Result := False;
+end;
+
+function UninstallService:Boolean;
+begin
+  Result := DoServiceOperation('uninstall',true);
+end;
+
+function InstallService:Boolean;
+begin
+  Result := DoServiceOperation('install',true);
+end;
+
+function StartService:Boolean;
+begin
+  Result := DoServiceOperation('start',true);
+end;
+
+procedure CustomUpdateUnInstallStatus(statusMsg:string);
+begin
+  if (UninstallProgressForm <> nil) and (UninstallProgressForm.StatusLabel <> nil) then
+    UninstallProgressForm.StatusLabel.Caption := statusMsg;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if (CurStep=ssPostInstall) then
+  begin
+    if InstallService() = false then
+      MsgBox('Unable to install the Service', mbError, MB_OK);
+
+    if StartService() = false then
+      MsgBox('Unable to start the Service', mbError, MB_OK);
+      
+    SetFirewallException('QuickDeployServer', ExpandConstant('{app}\Server\{#ServiceFileName}'));
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if (CurUninstallStep=usUninstall) then
+  begin
+    CustomUpdateUnInstallStatus('Stopping and uninstalling the services');        
+    UnInstallService();
+  end;
+
+  if (CurUninstallStep=usPostUninstall) then
+  begin    
+    RemoveFirewallException(ExpandConstant('{app}\Server\{#ServiceFileName}'));
+  end;
+end;

--- a/ci.bat
+++ b/ci.bat
@@ -1,0 +1,16 @@
+@ECHO OFF
+powershell Set-ExecutionPolicy Unrestricted
+powershell Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+powershell Unblock-File .\Build\CI\build.ps1
+pushd .\Build\CI\
+
+ECHO QuickDeploy CI Tool
+
+powershell .\build.ps1 -Verbosity Minimal -Command="%1"
+
+popd
+popd
+popd
+popd
+
+@ECHO ON


### PR DESCRIPTION
I have added support for creating setup file based on innosetup and a simple cmd line build tool (based on cakebuild) to build and create the installer.

To create a build + create installer, you just need to run (in the root)

`ci.bat pkg`

The installer allows the users to install the service, add firewall rules automatically. Having an installer will allow non programmers to deploy the app with ease. I hope you can merge this change and create a new installer and add it in GitHub release section so that people can directly download the app.
